### PR TITLE
Treat list custom json facebook with test

### DIFF
--- a/rasa/core/channels/facebook.py
+++ b/rasa/core/channels/facebook.py
@@ -280,8 +280,14 @@ class MessengerBot(OutputChannel):
     ) -> None:
         """Sends custom json data to the output."""
 
-        recipient_id = json_message.pop("sender", {}).pop("id", None) or recipient_id
-
+        if isinstance(json_message, list):
+            if isinstance(json_message.pop(), list):
+                recipient_id = json_message.pop().pop() or recipient_id
+            else:
+                recipient_id = json_message.pop().pop("id", None) or recipient_id
+        else:
+            recipient_id = json_message.pop("sender", {}).pop("id", None) or recipient_id
+            
         self.messenger_client.send(json_message, recipient_id, "RESPONSE")
 
     @staticmethod

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -143,29 +143,6 @@ async def test_console_input():
 
 
 # USED FOR DOCS - don't rename without changing in the docs
-def test_facebook_channel():
-    # START DOC INCLUDE
-    from rasa.core.channels.facebook import FacebookInput
-
-    input_channel = FacebookInput(
-        fb_verify="YOUR_FB_VERIFY",
-        # you need tell facebook this token, to confirm your URL
-        fb_secret="YOUR_FB_SECRET",  # your app secret
-        fb_access_token="YOUR_FB_PAGE_ACCESS_TOKEN"
-        # token for the page you subscribed to
-    )
-
-    s = rasa.core.run.configure_app([input_channel], port=5004)
-    # END DOC INCLUDE
-    # the above marker marks the end of the code snipped included
-    # in the docs
-    routes_list = utils.list_routes(s)
-
-    assert routes_list["fb_webhook.health"].startswith("/webhooks/facebook")
-    assert routes_list["fb_webhook.webhook"].startswith("/webhooks/facebook/webhook")
-
-
-# USED FOR DOCS - don't rename without changing in the docs
 def test_webexteams_channel():
     # START DOC INCLUDE
     from rasa.core.channels.webexteams import WebexTeamsInput
@@ -635,13 +612,4 @@ def test_set_console_stream_reading_timeout(monkeypatch: MonkeyPatch):
 
     assert console._get_stream_reading_timeout() == ClientTimeout(expected)
 
-def test_facebook_send_custon_json_list():
-    json_with_list = [['example text']]
-    json_with_list_else = [{"id": 'example text'}]
-    assert json_with_list.pop().pop() == 'example text'
-    assert json_with_list_else.pop().pop("id", None) == 'example text' 
-
-def test_facebook_send_custon_json():
-    json_without_list = {'sender': {'id': 'example text'}}
-    assert json_without_list.pop("sender", {}).pop("id", None) == 'example text'
 

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -634,3 +634,14 @@ def test_set_console_stream_reading_timeout(monkeypatch: MonkeyPatch):
     monkeypatch.setenv(console.STREAM_READING_TIMEOUT_ENV, str(100))
 
     assert console._get_stream_reading_timeout() == ClientTimeout(expected)
+
+def test_facebook_send_custon_json_list():
+    json_with_list = [['example text']]
+    json_with_list_else = [{"id": 'example text'}]
+    assert json_with_list.pop().pop() == 'example text'
+    assert json_with_list_else.pop().pop("id", None) == 'example text' 
+
+def test_facebook_send_custon_json():
+    json_without_list = {'sender': {'id': 'example text'}}
+    assert json_without_list.pop("sender", {}).pop("id", None) == 'example text'
+

--- a/tests/core/test_facebook.py
+++ b/tests/core/test_facebook.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Dict
+from unittest.mock import patch, MagicMock
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from aiohttp import ClientTimeout
+from aioresponses import aioresponses
+from sanic import Sanic
+
+import rasa.core.run
+from rasa.core import utils
+from rasa.core.channels import RasaChatInput, console
+from rasa.core.channels.channel import UserMessage
+from rasa.core.channels.rasa_chat import (
+    JWT_USERNAME_KEY,
+    CONVERSATION_ID_KEY,
+    INTERACTIVE_LEARNING_PERMISSION,
+)
+from rasa.core.channels.telegram import TelegramOutput
+from rasa.utils.endpoints import EndpointConfig
+from tests.core import utilities
+
+# this is needed so that the tests included as code examples look better
+from tests.utilities import json_of_latest_request, latest_request
+
+logger = logging.getLogger(__name__)
+
+# USED FOR DOCS - don't rename without changing in the docs
+def test_facebook_channel():
+    # START DOC INCLUDE
+    from rasa.core.channels.facebook import FacebookInput
+
+    input_channel = FacebookInput(
+        fb_verify="YOUR_FB_VERIFY",
+        # you need tell facebook this token, to confirm your URL
+        fb_secret="YOUR_FB_SECRET",  # your app secret
+        fb_access_token="YOUR_FB_PAGE_ACCESS_TOKEN"
+        # token for the page you subscribed to
+    )
+
+    s = rasa.core.run.configure_app([input_channel], port=5004)
+    # END DOC INCLUDE
+    # the above marker marks the end of the code snipped included
+    # in the docs
+    routes_list = utils.list_routes(s)
+
+    assert routes_list["fb_webhook.health"].startswith("/webhooks/facebook")
+    assert routes_list["fb_webhook.webhook"].startswith("/webhooks/facebook/webhook")
+
+def test_facebook_send_custon_json_list():
+    json_with_list = [['example text']]
+    json_with_list_else = [{"id": 'example text'}]
+    assert json_with_list.pop().pop() == 'example text'
+    assert json_with_list_else.pop().pop("id", None) == 'example text' 
+
+def test_facebook_send_custon_json():
+    json_without_list = {'sender': {'id': 'example text'}}
+    assert json_without_list.pop("sender", {}).pop("id", None) == 'example text'


### PR DESCRIPTION
updates send_custom_json function and adds tests for facebook


**Status (please check what you already did)**:
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
