### PR TITLE
[WIP] Add pytest.warns() to catch raised UserWarning at softmax tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+filterwarnings =
+    ignore:.*model_confidence is set to.*:UserWarning
 markers =
     skip_on_windows: mark a test as a test that shouldn't be executed on Windows.
     sequential: mark tests than cannot be ran in parallel (e.g. because they need access to the same resource).

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -106,7 +106,6 @@ from rasa.utils.tensorflow.constants import (
     ENTITY_RECOGNITION,
     CONSTRAIN_SIMILARITIES,
     MODEL_CONFIDENCE,
-    LINEAR_NORM,
     SOFTMAX,
     BILOU_FLAG,
 )
@@ -292,7 +291,7 @@ class TEDPolicy(Policy):
         CONSTRAIN_SIMILARITIES: False,
         # Model confidence to be returned during inference. Possible values -
         # 'softmax' and 'linear_norm'.
-        MODEL_CONFIDENCE: LINEAR_NORM,
+        MODEL_CONFIDENCE: SOFTMAX,
         # 'BILOU_flag' determines whether to use BILOU tagging or not.
         # If set to 'True' labelling is more rigorous, however more
         # examples per entity are required.

--- a/rasa/core/policies/ted_policy.py
+++ b/rasa/core/policies/ted_policy.py
@@ -106,6 +106,7 @@ from rasa.utils.tensorflow.constants import (
     ENTITY_RECOGNITION,
     CONSTRAIN_SIMILARITIES,
     MODEL_CONFIDENCE,
+    LINEAR_NORM,
     SOFTMAX,
     BILOU_FLAG,
 )
@@ -291,7 +292,7 @@ class TEDPolicy(Policy):
         CONSTRAIN_SIMILARITIES: False,
         # Model confidence to be returned during inference. Possible values -
         # 'softmax' and 'linear_norm'.
-        MODEL_CONFIDENCE: SOFTMAX,
+        MODEL_CONFIDENCE: LINEAR_NORM,
         # 'BILOU_flag' determines whether to use BILOU tagging or not.
         # If set to 'True' labelling is more rigorous, however more
         # examples per entity are required.

--- a/tests/core/test_training.py
+++ b/tests/core/test_training.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pathlib import Path
 from unittest.mock import Mock
 from _pytest.monkeypatch import MonkeyPatch
@@ -83,14 +85,15 @@ async def test_training_script_with_max_history_set(
     policy_train = Mock()
     monkeypatch.setattr(TEDPolicy, "train", policy_train)
 
-    await train(
-        domain_path,
-        stories_path,
-        tmpdir,
-        interpreter=RegexInterpreter(),
-        policy_config="data/test_config/max_hist_config.yml",
-        additional_arguments={},
-    )
+    with pytest.warns(UserWarning):
+        await train(
+            domain_path,
+            stories_path,
+            tmpdir,
+            interpreter=RegexInterpreter(),
+            policy_config="data/test_config/max_hist_config.yml",
+            additional_arguments={},
+        )
     agent = Agent.load(tmpdir)
 
     expected_max_history = {FormPolicy: 2, RulePolicy: None}

--- a/tests/nlu/featurizers/test_featurizer.py
+++ b/tests/nlu/featurizers/test_featurizer.py
@@ -88,9 +88,10 @@ def test_flexible_nlu_pipeline():
     )
     sentence_feature_dim = message.features[0].features.shape[1]
 
-    classifier = DIETClassifier(
-        component_config={FEATURIZERS: ["cvf_word", "LexicalSyntacticFeaturizer"]}
-    )
+    with pytest.warns(UserWarning):
+        classifier = DIETClassifier(
+            component_config={FEATURIZERS: ["cvf_word", "LexicalSyntacticFeaturizer"]}
+        )
     model_data = classifier.preprocess_train_data(training_data)
 
     assert len(model_data.get(TEXT).get(SENTENCE)) == 1

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -110,6 +110,16 @@ def test_confidence_loss_settings(
     component_config: Dict[Text, Any], raises_exception: bool
 ):
     component_config[SIMILARITY_TYPE] = INNER
+    if component_config[MODEL_CONFIDENCE] == SOFTMAX:
+        with pytest.warns(UserWarning):
+            run_confidense_loss_settings(component_config, raises_exception)
+    else:
+        run_confidense_loss_settings(component_config, raises_exception)
+
+
+def run_confidense_loss_settings(
+    component_config: Dict[Text, Any], raises_exception: bool
+):
     if raises_exception:
         with pytest.raises(InvalidConfigException):
             train_utils._check_confidence_setting(component_config)
@@ -130,6 +140,16 @@ def test_confidence_similarity_settings(
     component_config: Dict[Text, Any], raises_exception: bool
 ):
     component_config[LOSS_TYPE] = SOFTMAX
+    if component_config[MODEL_CONFIDENCE] == SOFTMAX:
+        with pytest.warns(UserWarning):
+            run_confidence_similarity_settings(component_config, raises_exception)
+    else:
+        run_confidence_similarity_settings(component_config, raises_exception)
+
+
+def run_confidence_similarity_settings(
+    component_config: Dict[Text, Any], raises_exception: bool
+):
     if raises_exception:
         with pytest.raises(InvalidConfigException):
             train_utils._check_confidence_setting(component_config)

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -110,16 +110,6 @@ def test_confidence_loss_settings(
     component_config: Dict[Text, Any], raises_exception: bool
 ):
     component_config[SIMILARITY_TYPE] = INNER
-    if component_config[MODEL_CONFIDENCE] == SOFTMAX:
-        with pytest.warns(UserWarning):
-            run_confidense_loss_settings(component_config, raises_exception)
-    else:
-        run_confidense_loss_settings(component_config, raises_exception)
-
-
-def run_confidense_loss_settings(
-    component_config: Dict[Text, Any], raises_exception: bool
-):
     if raises_exception:
         with pytest.raises(InvalidConfigException):
             train_utils._check_confidence_setting(component_config)
@@ -140,16 +130,6 @@ def test_confidence_similarity_settings(
     component_config: Dict[Text, Any], raises_exception: bool
 ):
     component_config[LOSS_TYPE] = SOFTMAX
-    if component_config[MODEL_CONFIDENCE] == SOFTMAX:
-        with pytest.warns(UserWarning):
-            run_confidence_similarity_settings(component_config, raises_exception)
-    else:
-        run_confidence_similarity_settings(component_config, raises_exception)
-
-
-def run_confidence_similarity_settings(
-    component_config: Dict[Text, Any], raises_exception: bool
-):
     if raises_exception:
         with pytest.raises(InvalidConfigException):
             train_utils._check_confidence_setting(component_config)


### PR DESCRIPTION
**Proposed changes**:
- Update TEPPolicy confidence model
- Add pytest.warns() to catch UserWarning at softmax tests

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
